### PR TITLE
Fix typos on quickstart page, fixes #1

### DIFF
--- a/content/docs/quickstart.md
+++ b/content/docs/quickstart.md
@@ -4,16 +4,16 @@ title: Quick Start
 
 # Quick Start : Build your first game
 
-### Download and Install Excalibur 
+### Download and Install Excalibur
 
 <a href="https://github.com/excaliburjs/Excalibur/releases/tag/v{{pkg.version}}" class="btn btn-primary btn-lg">**Latest Release:** {{pkg.version}}</a>
 
 Review the [install guide](/docs/install.html) for instructions.
 
 
-### Build your game script
+### Build Your Game Script
 
-Create a script in your project, here I've named it `game.js`. Excalibur games are built off of the ex.Engine container. It is important to start the engine once you are done building your game.
+Create a script in your project, here I've named it `game.js`. Excalibur games are built off of the `ex.Engine` container. It is important to start the engine once you are done building your game.
 
 >ProTip&trade;  Call `game.start()` right away so you don't forget
 
@@ -21,8 +21,8 @@ Create a script in your project, here I've named it `game.js`. Excalibur games a
 ```javascript
 // game.js
 
-// Create an instance of the engine. 
-// I'm specifying that the game be 800 pixels wide by 600 pixels tall. 
+// Create an instance of the engine.
+// I'm specifying that the game be 800 pixels wide by 600 pixels tall.
 // If no dimensions are specified the game will be fullscreen.
 var game = new ex.Engine(800, 600);
 // todo build awesome game here
@@ -48,15 +48,15 @@ Open a browser and view the blank blue screen of goodness.
 
 That's cool, but let's make something more interesting on the screen.
 
-To do this Excalibur uses a primitive called an `Actor`, and places actors into a `Scene`. Think of actors like you would the actors in a play. Actors are the primary way to draw things to the screen.
 
+To do this Excalibur uses a primitive called an `Actor`, and places actors into a `Scene`. Think of actors like you would the actors in a play. Actors are the primary way to draw things to the screen.
 
 > ProTip&trade; Actors must be added to a scene to be drawn or updated! `game.addChild(actor)` Will add an actor to the current scene.
 
 ```javascript
 // game.js
 
-// Create an instance of the engine. 
+// Create an instance of the engine.
 var game = new ex.Engine(800, 600);
 
 // Create an actor with x position of 100px,
@@ -68,7 +68,7 @@ var paddle = new ex.Actor(100, game.getHeight() - 40, 200, 20);
 // color constants
 paddle.color = ex.Color.Chartreuse;
 
-// `game.addChild` is the same as calling 
+// `game.addChild` is the same as calling
 // `game.currentScene.addChild`
 game.addChild(paddle);
 
@@ -77,12 +77,12 @@ game.start();
 
 ```
 
-Open up your favorite browser and you should see something like this
+Open up your favorite browser and you should see something like this:
 ![Hello World Excalibur](images/quickstart/breakoutPartial.png "Hello World Excalibur")
 
 
 That's neat, but this game is way more fun if things move around. Let's make the paddle follow the mouse around in the x direction.
-   
+
 ```javascript
 // Add a mouse move listener
 game.on('mousemove', function (ev) {
@@ -93,7 +93,7 @@ game.on('mousemove', function (ev) {
 What's breakout without the ball? To make the ball bounce, Excalibur comes prebuilt with an "elastic" collision type that does naive elastic collisions, which is sufficient for breakout.
 
 ```javascript
-// Create a "ball"
+// Create a ball
 var ball = new ex.Actor(100, 300, 20, 20);
 
 // Set the color
@@ -105,7 +105,7 @@ ball.dx = 100;
 // Set the y velocity in pixels per second
 ball.dy = 100;
 
-// Set the collision Type to elastic so 
+// Set the collision Type to elastic
 ball.collisionType = ex.CollisionType.Elastic;
 
 // Add the ball to the current scene
@@ -118,7 +118,7 @@ The ball will now bounce off of the paddle, but does not bounce with the side of
 ```javascript
 // Wire up to the update event
 ball.on('update', function () {
-    // If the ball collides with the left side 
+    // If the ball collides with the left side
     // of the screen reverse the x velocity
     if (this.x < 0) {
         this.dx *= -1;
@@ -134,12 +134,12 @@ ball.on('update', function () {
     // of the screen reverse the y velocity
     if (this.y < 0) {
         this.dy *= -1;
-    }    
+    }
 });
 
 ```
 
-Don't like square balls, me neither. You can create your own custom drawing function like so
+Don't like square balls? Me neither. You can create your own custom drawing function like so:
 
 
 ```javascript
@@ -166,7 +166,7 @@ Breakout needs some bricks to break. To do this we calculate our brick layout an
 // Build Bricks
 
 // Padding between bricks
-var padding = 20;//px
+var padding = 20; // px
 
 var columns = 5;
 var rows = 3;
@@ -175,7 +175,7 @@ var brickColor = [ex.Color.Violet, ex.Color.Orange, ex.Color.Yellow];
 
 // Individual brick width with padding factored in
 var brickWidth = game.getWidth() / columns - padding - padding/columns; // px
-var brickHeight = 30;// px
+var brickHeight = 30; // px
 var bricks = [];
 for (var j = 0; j < rows; j++) {
     for (var i = 0; i < columns; i++) {
@@ -211,11 +211,6 @@ ball.on('exitviewport', function(){
 ```
 
 ![Breakout Example Excalibur](images/quickstart/breakoutFinal.png "Breakout Example Excalibur")
-Congratulations! You have just created your first game in Excalibur! Please review the documentation for more examples and an API reference.
+Congratulations! You have just created your first game in Excalibur! Please review the documentation for more examples and an [API Reference](/docs/api).
 
 <iframe width="100%" height="700" src="http://jsfiddle.net/excaliburjs/6Ay9S/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
-
-
-
-
-


### PR DESCRIPTION
I had original created #1 before I realized there was already a [commit](https://github.com/excaliburjs/excaliburjs.github.io/commit/ce7d171426706a6b6c6b1063fae39456623692dc) that existed for it. Some of the more nitpicky items remain in this PR.

Also note I didn't intend to remove trailing spaces in this PR, my text editor did it automatically upon save. I can remove those changes and rebase if necessary.
