### PR TITLE
Add experimental decorator to doc site build

### DIFF
--- a/docs.js
+++ b/docs.js
@@ -27,6 +27,7 @@ console.log("Executing typedoc...");
 
 child_process.execSync(BUILD_CMD + 
 	' --target ES5' +
+	' --experimentalDecorators' +
 	' --name "Excalibur.js Edge API Documentation"' +
 	' --readme none' +
 	' --mode file' +	


### PR DESCRIPTION
For https://github.com/excaliburjs/Excalibur/pull/728

Changes:
* Update docs.js to include the experimentalDecorators tsc flag