### PR TITLE
docs: Update documented usage for label constructor

### DIFF
--- a/docs/14-ui.mdx
+++ b/docs/14-ui.mdx
@@ -181,7 +181,7 @@ to be drawn and updated on-screen.
 ```js
 const game = new ex.Engine()
 // constructor
-const label = new ex.Label('Hello World', 50, 50, '10px Arial')
+const label = new ex.Label('Hello World', 50, 50, 'Arial')
 // properties
 const label = new ex.Label()
 label.pos.x = 50


### PR DESCRIPTION
Hello,

This minor change is intended to supplement the following pull request: excaliburjs/Excalibur#1672

It's a correction to the sample usage of a particular `Label` constructor. I had a quick scan through the other `.mdx` files in the `/docs` folder, but it looks like this is the only relevant correction to be made.