### PR TITLE
Fix reference to `Engine.showDebug`

### DIFF
--- a/docs/04-architecture.mdx
+++ b/docs/04-architecture.mdx
@@ -266,4 +266,4 @@ Have you implemented state management in your Excalibur game? [Let us know](http
 
 ## Enabling debug mode
 
-Call [[Engine.setDebug]] with a `true` or `false` to enable or disable Excalibur's debug feature. This will enable [actor debug drawing](/docs/actors#debug-draw) to help diagnose drawing issues.
+Call [[Engine.showDebug]] with a `true` or `false` to enable or disable Excalibur's debug feature. This will enable [actor debug drawing](/docs/actors#debug-draw) to help diagnose drawing issues.


### PR DESCRIPTION
Reference: https://excaliburjs.com/docs/api/edge/classes/Engine.html#showDebug

Currently, it's pointing to `Engine.setDebug`:
![image](https://user-images.githubusercontent.com/418083/139150968-2c605630-5871-46ff-9ed1-40a8be38d6f6.png)
