### PR TITLE
style: Improve visibility of certain links

### DIFF
--- a/ui/src/site/collections/message.overrides
+++ b/ui/src/site/collections/message.overrides
@@ -1,3 +1,7 @@
 /*******************************
         Site Overrides
 *******************************/
+
+.ui.info.message a {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Make links within `<Note>` elements more prominent.

An override is added to /collections/messages.
This affects the <Note> element in its `info` variant.
See Semantic-UI docs:
https://semantic-ui.com/collections/message.html

Closes #116

---
## Demo

_Before_ - I can't tell if there are links here at a glance.

![Screenshot 2021-10-30 at 20 54 58](https://user-images.githubusercontent.com/59713582/139555668-06c69849-64ad-4c9e-be74-9efe426b113a.png)

_After_ - Better.
![Screenshot 2021-10-30 at 20 42 19](https://user-images.githubusercontent.com/59713582/139555678-37e9d4be-f32b-4148-84ea-31cbd30bd069.png)

---
❗ I'm not sure how the building process works with this site. I had to run `gulp build` for this change to register locally (and it took me a while to figure this out :D). 
