### PR TITLE
fix: broken links in docs

### DIFF
--- a/docs/03-actors.mdx
+++ b/docs/03-actors.mdx
@@ -233,7 +233,7 @@ const canvas = new ex.Canvas({
 actor.graphics.use(canvas)
 ```
 
-Override the [[GraphicsComponent]] [[Actor.graphics.onPreDraw]] or [[Actor.graphics.onPostDraw]] methods to customize the draw logic at different points in the loop.
+Override the [[GraphicsComponent.onPreDraw|Actor.graphics.onPreDraw]] or [[GraphicsComponent.onPostDraw|Actor.graphics.onPostDraw]] methods to customize the draw logic at different points in the loop.
 
 <Note>
 
@@ -243,7 +243,7 @@ Reference [Actor lifecycle](#actor-lifecycle) for a breakdown of each phase and 
 
 ### Pre-draw
 
-[[Actor.graphics.onPreDraw]] is run _before_ the core draw logic to prepare the frame.
+[[GraphicsComponent.onPreDraw|Actor.graphics.onPreDraw]] is run _before_ the core draw logic to prepare the frame.
 
 <Note>
 
@@ -269,7 +269,7 @@ class Player extends ex.Actor {
 
 ### Post-draw
 
-[[Actor.graphics.onPostDraw]] is run _after_ the core draw and will draw in the current frame.
+[[GraphicsComponent.onPostDraw|Actor.graphics.onPostDraw]] is run _after_ the core draw and will draw in the current frame.
 
 <Note>
 

--- a/docs/04-graphics.mdx
+++ b/docs/04-graphics.mdx
@@ -28,13 +28,13 @@ const game = new ex.Engine(...);
 
 ## How to use the Graphics Component
 
-1. Graphics using [[ImageSource|images]] (and any [[Resource]]) must be [[loaded]] before use
+1. Graphics using [[ImageSource|images]] (and any [[Resource]]) must be [loaded](assets) before use
 2. Graphics like [[Sprite|Sprites]] are like a window into an [[ImageSource|image]]
-3. Graphics like [[Canvas]]([[Raster|Rasters]]) produce internal bitmap's which are large in memory and should be used sparingly or cached
+3. Graphics like [[Canvas]] produce internal bitmap's which are large in memory and should be used sparingly or cached
 4. Graphics can be added to the [[GraphicsComponent]] on an [[Actor]] or [[Entity]]
 5. Direct access to the [[ExcaliburGraphicsContext]]
 
-For most games, you will be using the graphics component off of [[Actors|Actors]] or plain [[Entity|Entities]].
+For most games, you will be using the graphics component off of [[Actor|Actors]] or plain [[Entity|Entities]].
 
 ```typescript
 const image = new ex.ImageSource('./path/to/my/image.png')
@@ -157,9 +157,9 @@ actor.graphics.getLayer('default').show(myAnimation)
 
 ## Graphics
 
-Excalibur `ex.Graphic`s break into 2 main categories, `ex.[[Sprite]]` based and `ex.[[Raster]]` based. That is to say Raster and non-Raster graphics.
+Excalibur `ex.Graphic`s break into 2 main categories, [[Sprite]] based and [[Raster]] based. That is to say Raster and non-Raster graphics.
 
-[[Graphics]] have a bunch of useful feature that work for ALL types of graphics
+[[Graphic|Graphics]] have a bunch of useful feature that work for ALL types of graphics
 
 - `clone(): Graphic`
 
@@ -199,7 +199,7 @@ Excalibur `ex.Graphic`s break into 2 main categories, `ex.[[Sprite]]` based and 
 
 #### Canvas
 
-For drawing hooks the `ExcaliburGraphicsContext` is replacing the browser `CanvasRenderingContext2D`. But if you need to do some custom drawing using the `CanvasRenderingContext2D` the new [`Canvas`](https://excaliburjs.com/docs/api/edge/classes/Canvas.html) graphic has your back.
+For drawing hooks the `ExcaliburGraphicsContext` is replacing the browser `CanvasRenderingContext2D`. But if you need to do some custom drawing using the `CanvasRenderingContext2D` the new [[Canvas]] graphic has your back.
 
 `embed:excalibur-snippets/src/canvas/main.ts{snippet: "canvas"}`
 

--- a/docs/05.1-entities.mdx
+++ b/docs/05.1-entities.mdx
@@ -3,7 +3,7 @@ title: Entities
 path: /docs/entities
 ---
 
-An [[Entity]] in is an empty container for [[Components]], alone an Entity has little behavior.
+An [[Entity]] in is an empty container for [[Component|Components]], alone an Entity has little behavior.
 
 They are useful for defining bare bones game objects with custom behavior.
 

--- a/docs/05.3-systems.mdx
+++ b/docs/05.3-systems.mdx
@@ -34,7 +34,7 @@ The motion system implements motion on entities, like Actors moving with velocit
 
 This system makes use of the [[TransformComponent]] and [[MotionComponent]] to implemenat motion.
 
-If a [[BodyComponent]] is present that will be used to apply sleep or global acceleration [[ex.Physics.acc]] to all [[CollisionType.Active]] bodies.
+If a [[BodyComponent]] is present that will be used to apply sleep or global acceleration [[Physics.acc]] to all [[CollisionType.Active]] bodies.
 
 ### [[CollisionSystem]]
 


### PR DESCRIPTION
- fix broken links in docs

This should remove all the warnings about broken symbol links in docs