### PR TITLE
chore(deps): upgrade Gatsby typedoc packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "gatsby-remark-typedoc-symbol-links": "2.0.0",
         "gatsby-source-filesystem": "3.14.0",
         "gatsby-source-github-api": "1.0.0",
-        "gatsby-source-typedoc": "1.4.0",
+        "gatsby-source-typedoc": "1.4.1",
         "gatsby-transformer-remark": "3.2.0",
         "gatsby-transformer-sharp": "3.14.0",
         "prismjs": "1.25.0",
@@ -14938,9 +14938,9 @@
       }
     },
     "node_modules/gatsby-source-typedoc": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-typedoc/-/gatsby-source-typedoc-1.4.0.tgz",
-      "integrity": "sha512-++aTjvEyGqjRqnc77fYM2RNsgfrnweImaUEkvjY3HoujrMn+d3JEhruKOXwJNJe3DakOBKlUNKc435fQsb+Raw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/gatsby-source-typedoc/-/gatsby-source-typedoc-1.4.1.tgz",
+      "integrity": "sha512-XZk+LFuZMOilRbK1I38TokYnzt2ON/cOpJX4f3lvUQxk1/hFiJf/C40UdiFhrg7mMBz5QrGy8F49JH5hE6Oldg==",
       "peerDependencies": {
         "typedoc": ">= 0.17"
       }
@@ -49496,9 +49496,9 @@
       }
     },
     "gatsby-source-typedoc": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-typedoc/-/gatsby-source-typedoc-1.4.0.tgz",
-      "integrity": "sha512-++aTjvEyGqjRqnc77fYM2RNsgfrnweImaUEkvjY3HoujrMn+d3JEhruKOXwJNJe3DakOBKlUNKc435fQsb+Raw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/gatsby-source-typedoc/-/gatsby-source-typedoc-1.4.1.tgz",
+      "integrity": "sha512-XZk+LFuZMOilRbK1I38TokYnzt2ON/cOpJX4f3lvUQxk1/hFiJf/C40UdiFhrg7mMBz5QrGy8F49JH5hE6Oldg==",
       "requires": {}
     },
     "gatsby-telemetry": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "gatsby-remark-typedoc-symbol-links": "2.0.0",
     "gatsby-source-filesystem": "3.14.0",
     "gatsby-source-github-api": "1.0.0",
-    "gatsby-source-typedoc": "1.4.0",
+    "gatsby-source-typedoc": "1.4.1",
     "gatsby-transformer-remark": "3.2.0",
     "gatsby-transformer-sharp": "3.14.0",
     "prismjs": "1.25.0",


### PR DESCRIPTION
With Typedoc 0.22+ there are some breaking changes in the Typedoc output 😢 

**Update:** But luckily since the plugin uses `ReflectionKind` directly, it's OK. 🎉 