### PR TITLE
Update 07-random.mdx

### DIFF
--- a/docs/07-random.mdx
+++ b/docs/07-random.mdx
@@ -16,7 +16,7 @@ const rand = new ex.Random(1234)
 // random integer between [min, max]
 rand.integer(0, 10)
 
-// random floating number between [min, max)
+// random floating number between [min, max]
 rand.floating(0, 10)
 
 // random true or false
@@ -24,7 +24,7 @@ rand.bool()
 // random true or false with 40% likelihood of being true
 rand.bool(0.4)
 
-// next floating point between [0, 1)
+// next floating point between [0, 1]
 rand.next()
 
 // next integer between 0 and Number.MAX_SAFE_INTEGER
@@ -38,8 +38,8 @@ rand.pickSet([0, 1, 4, 10], 2)
 // pick a 4 random elements from an array, allowing duplicates
 rand.pickSet([0, 1, 4, 10], 4, true)
 
-// generate an array of 10 random numbers between [min, max]
-rand.range(10, 0, 10)
+// generate an array of 9 random numbers between [min, max]
+rand.range(9, 0, 10)
 
 // randomly shuffle an array using Fisher/Yates algorithm
 rand.shuffle([0, 1, 2, 3, 4])


### PR DESCRIPTION
 - nit: Swapped a few mismatched `)` with `]`
 - nit 2: Changed `10` to `9` because it wasn't clear from the example if the argument order was `rand.range(min, max, length)` or `rand.range(length, min, max)`