### PR TITLE
Removes reference to deprecated input import site

### DIFF
--- a/docs/04-architecture.mdx
+++ b/docs/04-architecture.mdx
@@ -23,7 +23,7 @@ const game = new ex.Engine({
   height: 600, // the height of the canvas
   canvasElementId: '', // the DOM canvas element ID, if you are providing your own
   displayMode: ex.DisplayMode.FitScreen, // the display mode
-  pointerScope: ex.Input.PointerScope.Document, // the scope of capturing pointer (mouse/touch) events
+  pointerScope: ex.PointerScope.Document, // the scope of capturing pointer (mouse/touch) events
 })
 // call game.start, which is a Promise
 game.start().then(function () {
@@ -219,7 +219,7 @@ var player = new ex.Actor(...);
 // Enable pointer events for this actor
 player.enableCapturePointer = true;
 // subscribe to pointerdown event
-player.on("pointerdown", function (evt: ex.Input.PointerEvent) {
+player.on("pointerdown", function (evt: ex.PointerEvent) {
   console.log("Player was clicked!");
 });
 // turn off subscription

--- a/docs/10.1-input.mdx
+++ b/docs/10.1-input.mdx
@@ -20,7 +20,7 @@ Access [[Engine.input]] to see if any input is being tracked during the current 
 class Player extends ex.Actor {
   public update(engine, delta) {
     if (
-      engine.input.keyboard.isHeld(ex.Input.Keys.W) ||
+      engine.input.keyboard.isHeld(ex.Keys.W) ||
       engine.input.gamepads.at(0).getAxes(ex.Input.Axes.LeftStickY) > 0.5
     ) {
       player._moveForward()

--- a/docs/10.2-keyboard.mdx
+++ b/docs/10.2-keyboard.mdx
@@ -27,13 +27,13 @@ It is recommended that keyboard actions that directly effect actors be queried, 
 class Player extends ex.Actor {
   public update(engine, delta) {
     if (
-      engine.input.keyboard.isHeld(ex.Input.Keys.W) ||
-      engine.input.keyboard.isHeld(ex.Input.Keys.Up)
+      engine.input.keyboard.isHeld(ex.Keys.W) ||
+      engine.input.keyboard.isHeld(ex.Keys.Up)
     ) {
       player._moveForward()
     }
 
-    if (engine.input.keyboard.wasPressed(ex.Input.Keys.Right)) {
+    if (engine.input.keyboard.wasPressed(ex.Keys.Right)) {
       player._fire()
     }
   }

--- a/docs/10.3-pointer.mdx
+++ b/docs/10.3-pointer.mdx
@@ -101,9 +101,9 @@ can inspect what type of pointer it is from the [[PointerEvent]] handled.
 
 ```js
 engine.input.pointers.primary.on('down', function (pe) {
-  if (pe.pointerType === ex.Input.PointerType.Mouse) {
+  if (pe.pointerType === ex.PointerType.Mouse) {
     ex.Logger.getInstance().info('Mouse event:', pe)
-  } else if (pe.pointerType === ex.Input.PointerType.Touch) {
+  } else if (pe.pointerType === ex.PointerType.Touch) {
     ex.Logger.getInstance().info('Touch event:', pe)
   }
 })
@@ -131,7 +131,7 @@ know that there are _n_ touches on the screen at once.
 function paint(color) {
   // create a handler for the event
   return function (pe) {
-    if (pe.pointerType === ex.Input.PointerType.Touch) {
+    if (pe.pointerType === ex.PointerType.Touch) {
       engine.canvas.fillStyle = color
       engine.canvas.fillRect(pe.x, pe.y, 5, 5)
     }

--- a/docs/12-ui.mdx
+++ b/docs/12-ui.mdx
@@ -132,7 +132,7 @@ const game = new ex.Engine({
    * Specify pointer scope to ensure that excalibur won't capture the mouse input
    * meant to be captured by HTML GUI
    */
-  pointerScope: ex.Input.PointerScope.Canvas,
+  pointerScope: ex.PointerScope.Canvas,
 })
 
 /**


### PR DESCRIPTION
Swaps references to `ex.Input.ABC` to `ex.ABC` in docs so readers will use the current approach. 